### PR TITLE
Use proper naming convention for Software Freedom Conservancy

### DIFF
--- a/_foundations/conservancy.md
+++ b/_foundations/conservancy.md
@@ -1,6 +1,6 @@
 ---
 title: "Software Freedom Conservancy"
-excerpt: "SFC helps promote, improve, develop, and defend Free, Libre, and Open Source Software (FLOSS) projects."
+excerpt: "Conservancy helps promote, improve, develop, and defend Free, Libre, and Open Source Software (FLOSS) projects."
 permalink: /foundations/conservancy
 layout: foundation
 header:
@@ -58,18 +58,18 @@ projects:
 
 ---
 
-## About The Software Freedom Conservancy (SFC)
+## About Software Freedom Conservancy
 
 Software Freedom Conservancy, Inc. is a 501(c)(3) not-for-profit organization incorporated in New York. Software Freedom Conservancy helps promote, improve, develop, and defend Free, Libre, and Open Source Software (FLOSS) projects. Conservancy provides a non-profit home and infrastructure for FLOSS projects. This allows FLOSS developers to focus on what they do best — writing and improving FLOSS for the general public — while Conservancy takes care of the projects' needs that do not relate directly to software development and documentation.
 
 ## How Individuals Can Get Involved {#individual}
 
-The SFC appreciates [individual supporters](https://sfconservancy.org/supporter/).
+Conservancy appreciates [individual supporters](https://sfconservancy.org/supporter/).
 
 ## How Projects Can Get Involved {#project}
 
-Projects can [apply to join](https://sfconservancy.org/projects/apply/) the SFC.
+Projects can [apply to join](https://sfconservancy.org/projects/apply/) Conservancy.
 
 ## How Companies Can Get Involved {#company}
 
-The SFC appreciates their many [corporate sponsors](https://sfconservancy.org/sponsors/).
+Conservancy appreciates their many [corporate sponsors](https://sfconservancy.org/sponsors/).


### PR DESCRIPTION
While many people use "SFC" to refer to Software Freedom Conservancy,
the organization itself uses "Conservancy".  It's just "Conservancy"
and not "The ... Conservancy".

I don't find a good reference for this usage but here's a change
to the Conservancy web site:
https://k.sfconservancy.org/website/changeset/12780197e5df85b433ab54c03871a98523a0db88

Note that http://sfconservancy.org/ doesn't use "SFC" anywhere.