### PR TITLE
Avoid ambiguity when refering to foundations

### DIFF
--- a/_includes/foundations-toc.html
+++ b/_includes/foundations-toc.html
@@ -2,10 +2,10 @@
   <nav class="toc">
     <header><h4 class="nav__title"><i class="fa fa-list-alt"></i> Foundations</h4></header>
     <ul class="toc__menu" id="toc">
-      <li><a href="{{ '/foundations/apache' | absolute_url }}">Apache</a></li>
-      <li><a href="{{ '/foundations/linux' | absolute_url }}">Linux</a></li>
+      <li><a href="{{ '/foundations/apache' | absolute_url }}">Apache Software Foundation</a></li>
+      <li><a href="{{ '/foundations/linux' | absolute_url }}">Linux Foundation</a></li>
       <li><a href="{{ '/foundations/conservancy' | absolute_url }}">Conservancy</a></li>
-      <li><a href="{{ '/foundations/eclipse' | absolute_url }}">Eclipse</a></li>
+      <li><a href="{{ '/foundations/eclipse' | absolute_url }}">Eclipse Foundation</a></li>
       <li><a href="{{ '/foundations/spi' | absolute_url }}">SPI</a></li>
       <li><a href="{{ '/foundations/owasp' | absolute_url }}">OWASP</a></li>
     </ul>


### PR DESCRIPTION
Use "Linux Foundation" insted of just "Linux" since "Linux" has too
many different uses that it's not clear it refers to the Linux
Foundation (for example, there's also kernel.org which might be
"Linux").

To be consistent, use the full name for Eclipse Foundation and
Apache Software Foundation.  The other abbreviations and short names
are common (Conservancy, SPI).